### PR TITLE
feat: add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "mopro-ai",
+  "description": "Mopro plugin for building mobile-native zero-knowledge proof apps",
+  "owner": {
+    "name": "zkmopro"
+  },
+  "plugins": [
+    {
+      "name": "mopro",
+      "description": "Build mobile-native zero-knowledge proof apps with mopro (Circom, Halo2, Noir \u2192 iOS, Android, Flutter, React Native, Web)",
+      "version": "0.1.0",
+      "author": {
+        "name": "zkmopro"
+      },
+      "source": ".",
+      "category": "development",
+      "homepage": "https://zkmopro.org",
+      "tags": ["zk", "zero-knowledge", "mobile", "mopro"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ Mopro is a developer toolkit for building mobile ZK apps. It uses Rust + UniFFI 
 
 ## Installation
 
+Add the mopro marketplace and install the plugin:
+
 ```bash
-claude plugin add /path/to/mopro-ai
-# or
+# In Claude Code:
+/plugin marketplace add zkmopro/mopro-ai
+/plugin install mopro
+```
+
+Or for local development:
+
+```bash
 claude --plugin-dir /path/to/mopro-ai
 ```
 


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` so the repo acts as a self-hosted single-plugin marketplace
- Update README installation instructions to use `/plugin marketplace add zkmopro/mopro-ai` + `/plugin install mopro`
- Keep local development `--plugin-dir` option as an alternative

## Test plan

- [x] Verify `.claude-plugin/marketplace.json` is valid JSON and has `"source": "."`
- [x] Verify `bash tests/validate-structure.sh` passes
- [x] Test `/plugin marketplace add zkmopro/mopro-ai` then `/plugin install mopro` in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)