### PR TITLE
feat: add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "mopro-ai",
+  "description": "Mopro plugin for building mobile-native zero-knowledge proof apps",
+  "owner": {
+    "name": "zkmopro"
+  },
+  "plugins": [
+    {
+      "name": "mopro",
+      "description": "Build mobile-native zero-knowledge proof apps with mopro (Circom, Halo2, Noir \u2192 iOS, Android, Flutter, React Native, Web)",
+      "version": "0.1.0",
+      "author": {
+        "name": "zkmopro"
+      },
+      "source": "./",
+      "category": "development",
+      "homepage": "https://zkmopro.org",
+      "tags": ["zk", "zero-knowledge", "mobile", "mopro"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ Mopro is a developer toolkit for building mobile ZK apps. It uses Rust + UniFFI 
 
 ## Installation
 
+Add the mopro marketplace and install the plugin:
+
 ```bash
-claude plugin add /path/to/mopro-ai
-# or
+# In Claude Code:
+/plugin marketplace add zkmopro/mopro-ai
+/plugin install mopro
+```
+
+Or for local development:
+
+```bash
 claude --plugin-dir /path/to/mopro-ai
 ```
 


### PR DESCRIPTION
## Summary
- Re-apply marketplace.json for plugin discovery (reverts and replaces #9)
- Fix `source` field from `"."` to `"./"` to satisfy schema validation — the schema requires relative paths to start with `"./"`
- Enables installation via `/plugin marketplace add zkmopro/mopro-ai`

## Test plan
- [x] Run `/plugin marketplace add git@github.com:zkmopro/mopro-ai.git` and confirm no validation errors
- [x] Verify the mopro plugin is listed after adding the marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)