### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "mopro",
       "description": "Build mobile-native zero-knowledge proof apps with mopro (Circom, Halo2, Noir \u2192 iOS, Android, Flutter, React Native, Web)",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "zkmopro"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mopro",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Build mobile-native zero-knowledge proof apps with mopro (Circom, Halo2, Noir \u2192 iOS, Android, Flutter, React Native, Web)",
   "author": {
     "name": "zkmopro",

--- a/skills/mopro-app/SKILL.md
+++ b/skills/mopro-app/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 license: MIT OR Apache-2.0
 metadata:
   author: zkmopro
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Mopro App Development

--- a/skills/mopro-device/SKILL.md
+++ b/skills/mopro-device/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 license: MIT OR Apache-2.0
 metadata:
   author: zkmopro
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Mopro Device Management

--- a/skills/mopro-env/SKILL.md
+++ b/skills/mopro-env/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: MIT OR Apache-2.0
 metadata:
   author: zkmopro
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Mopro Environment Setup

--- a/skills/mopro-project/SKILL.md
+++ b/skills/mopro-project/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 license: MIT OR Apache-2.0
 metadata:
   author: zkmopro
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Mopro Project Workflow

--- a/skills/mopro-test/SKILL.md
+++ b/skills/mopro-test/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 license: MIT OR Apache-2.0
 metadata:
   author: zkmopro
-  version: "0.3.0"
+  version: "0.3.1"
 ---
 
 # Mopro Testing


### PR DESCRIPTION
## Summary
- Bump version strings from `0.3.0` → `0.3.1` across all 7 files (plugin.json, marketplace.json, and 5 SKILL.md files)

### Changes since v0.3.0
- docs: add project detection prerequisite gate (#19)
- docs: add guardrails for --platforms flag values (#20)
- docs: exclude Flutter from mopro update workflow (#21)
- docs: fix simulator/emulator launch blocking (#22)
- chore: fix device bug, rewrite descriptions, add evals (#23)

## Test plan
- [x] Verify all 7 files now read `0.3.1`
- [ ] Squash merge and tag `v0.3.1` at the merged commit
- [ ] Create GitHub release with changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)