### PR TITLE
docs: add circuit naming, non-interactive CLI, and --help guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@ init → build → create → develop → update (repeat build→update as circu
 Flutter exception: skip `mopro update` — rebuild with
 `mopro build --platforms flutter` then `flutter pub get`.
 
-## CLI Quick Reference
-- `mopro init --project_name NAME --adapter circom,noir` (non-interactive)
+## CLI Quick Reference (Non-Interactive — Always Use These Forms)
+- `mopro init --project_name NAME --adapter circom,noir`
 - `mopro build --platforms ios --mode release --architectures aarch64-apple-ios-sim`
+- `mopro build --platforms android --mode release --architectures x86_64-linux-android`
 - `mopro build --platforms flutter --mode release` (Flutter — NOT --platforms ios)
 - `mopro build --platforms react-native --mode release` (RN — NOT --platforms ios)
 - `mopro create --framework flutter`
-- `mopro update --src ./ios_bindings --dest ../MyApp --no_prompt`
+- `mopro update --src ./MoproiOSBindings --dest ../MyApp --no_prompt`
 - `mopro bindgen --circuit-dir ./circuits --platforms ios`
 
 ## Guardrails
@@ -36,6 +37,16 @@ Flutter exception: skip `mopro update` — rebuild with
   `--platforms react-native`. NEVER use `--platforms ios` or
   `--platforms android` for Flutter or React Native apps — those produce
   native-only bindings that are incompatible.
+- NEVER run `mopro --help` or `mopro <cmd> --help` — all flags are documented
+  above and in skill references. Running --help wastes time and provides no
+  additional information.
+- ALWAYS pass all required flags (`--platforms`, `--mode`, `--architectures`)
+  to avoid interactive prompts. The CLI will prompt interactively if flags are
+  missing, which blocks non-interactive agents.
+- Circom circuit filenames: NEVER use underscores in circuit names. Use
+  camelCase (e.g., `challengeResponse.circom`, NOT `challenge_response.circom`).
+  Circom strips underscores from generated symbols, breaking `rust_witness!`
+  macro resolution.
 
 ## Project Detection
 Before running any mopro CLI command (build, create, update, bindgen), verify
@@ -86,6 +97,8 @@ All adapters require inputs as flat, one-dimensional JSON string mappings:
 - Halo2 RSA on mobile: Crashes (~5GB memory needed, mobile has ~3GB)
 - Flutter release: Must disable code shrinking (minifyEnabled false)
 - Android imports: Replace hyphens with underscores in `import uniffi.<name>.*`
+- Circom circuit names: No underscores — circom strips them from generated
+  symbols, causing `rust_witness!` resolution failures
 
 ## Validated Versions
 - mopro-cli / mopro-ffi: 0.3.x

--- a/skills/mopro-project/SKILL.md
+++ b/skills/mopro-project/SKILL.md
@@ -77,6 +77,10 @@ See references/project-structure.md for expected layout.
 
 **CRITICAL: Warn about build duration before starting.**
 
+**CRITICAL: Always use non-interactive mode.** Pass `--platforms`, `--mode`,
+and `--architectures` explicitly to every `mopro build` invocation. The CLI
+will prompt interactively if any flag is missing, which blocks AI agents.
+
 Gather required parameters:
 - **Platform(s)**: ios, android, flutter, react-native, web
 > **CRITICAL:** For Flutter apps use `--platforms flutter`, for React Native

--- a/skills/mopro-project/references/cli-reference.md
+++ b/skills/mopro-project/references/cli-reference.md
@@ -21,14 +21,14 @@ cargo install --path .
 
 Creates a new mopro project with Rust scaffolding and test vectors.
 
-**Interactive mode** (prompts for all options):
-```bash
-mopro init
-```
-
-**Non-interactive mode** (CI-friendly):
+**Non-interactive mode** (always use this for AI agents):
 ```bash
 mopro init --project_name my_zk_app --adapter circom,noir
+```
+
+**Interactive mode** (human terminal only — do NOT use in agents):
+```bash
+mopro init
 ```
 
 **Flags:**
@@ -43,14 +43,14 @@ mopro init --project_name my_zk_app --adapter circom,noir
 
 Compiles Rust project into platform-specific bindings.
 
-**Interactive mode:**
-```bash
-mopro build
-```
-
-**Non-interactive mode:**
+**Non-interactive mode** (always use this for AI agents):
 ```bash
 mopro build --platforms ios --mode release --architectures aarch64-apple-ios-sim
+```
+
+**Interactive mode** (human terminal only — do NOT use in agents):
+```bash
+mopro build
 ```
 
 **Flags:**
@@ -120,6 +120,9 @@ mopro bindgen --circuit-dir ./circuits --platforms ios
 ### `mopro --help`
 
 Shows all available commands and global flags.
+**AI agents should NOT run this command** — all flags are documented in this
+reference and in AGENTS.md. Running `--help` wastes time and provides no
+additional information beyond what is already here.
 
 ### `mopro --version`
 
@@ -134,6 +137,11 @@ Uses Groth16 proving system over BN254 or BLS12-381 curves.
 **Required artifacts** (place in `test-vectors/circom/`):
 - `<circuit_name>_final.zkey` — proving key from snarkjs trusted setup
 - `<circuit_name>.wasm` — witness generator compiled by circom
+
+**Circuit naming:** NEVER use underscores in Circom circuit filenames. Circom
+strips underscores from generated symbols, breaking `rust_witness!` macro
+resolution. Use camelCase (e.g., `challengeResponse.circom`, NOT
+`challenge_response.circom`).
 
 **Rust configuration** in `src/lib.rs`:
 ```rust

--- a/skills/mopro-project/references/troubleshooting.md
+++ b/skills/mopro-project/references/troubleshooting.md
@@ -201,6 +201,26 @@ import uniffi.my-zk-app.*  // WRONG — hyphens cause syntax error
 
 The generated `mopro.kt` file's package declaration will show the correct name.
 
+## 11. Circom Circuit Name with Underscores Breaks Witness Resolution
+
+**Symptoms:**
+- `rust_witness!` macro fails to resolve the witness module
+- Build error: `unresolved import` for the witness function
+- Circuit compiles fine but Rust build fails
+
+**Cause:** Circom strips underscores from generated symbol names. A circuit
+named `challenge_response` produces a witness module named `challengeresponse`,
+but `rust_witness!` expects `challenge_response`, causing a mismatch.
+
+**Fix:**
+1. Rename the `.circom` file to camelCase: `challengeResponse.circom`
+2. Recompile the circuit to regenerate `.zkey` and `.wasm` artifacts
+3. Update `src/lib.rs` to reference the new circuit name
+4. Replace artifacts in `test-vectors/circom/`
+
+**Prevention:** Always use camelCase for Circom circuit filenames. Never use
+underscores (e.g., `challengeResponse`, NOT `challenge_response`).
+
 ## General Debugging Tips
 
 **Check mopro version:**


### PR DESCRIPTION
## Summary
- Add guardrails to prevent underscore circuit names (circom strips underscores from generated symbols, breaking `rust_witness!` macro resolution)
- Enforce non-interactive CLI usage by requiring all flags (`--platforms`, `--mode`, `--architectures`) and reordering docs to show non-interactive mode first
- Discourage unnecessary `mopro --help` calls since all flags are already documented

## Changes
- **AGENTS.md**: Rename CLI header, add Android build example, add 3 new guardrails, add circom naming to Known Limitations
- **cli-reference.md**: Swap interactive/non-interactive ordering, add `--help` warning, add circom circuit naming note
- **troubleshooting.md**: Add entry #11 for underscore circuit naming issue
- **SKILL.md**: Add non-interactive mode reinforcement in Step 3

## Test plan
- [x] AGENTS.md stays under ~110 lines (109)
- [x] CLAUDE.md symlink resolves correctly
- [x] `bash tests/validate-structure.sh` passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)